### PR TITLE
TreeNode type exception log

### DIFF
--- a/Runtime/Fields/Variables/VariableBase.cs
+++ b/Runtime/Fields/Variables/VariableBase.cs
@@ -51,7 +51,7 @@ namespace Amlos.AI.Variables
         public bool IsNumericLike => Type == VariableType.Int || Type == VariableType.Float || Type == VariableType.Bool || Type == VariableType.UnityObject;
         /// <summary> Determine whether given variable can be a game object </summary>
         public bool IsFromGameObject => Value is GameObject or Component;
-        
+
         /// <summary> Whether the actual value of the variable is null </summary>/// <summary>
         /// is the variable null? only meaningful when <see cref="HasValue"/> is true
         /// </summary>
@@ -179,7 +179,8 @@ namespace Amlos.AI.Variables
                 {
                     position = transform.position;
                 }
-                else throw InvalidNodeException.InvalidValue(Type, this.Value);
+                else throw new InvalidOperationException(
+                $"Variable Type \"{Type}\" has invalid value: {this.Value}");
                 return position;
             }
         }

--- a/Runtime/Nodes/Actions/Movement/FixedJump.cs
+++ b/Runtime/Nodes/Actions/Movement/FixedJump.cs
@@ -1,4 +1,5 @@
-﻿using Amlos.AI.Variables;
+﻿using System;
+using Amlos.AI.Variables;
 using UnityEngine;
 
 namespace Amlos.AI.Nodes
@@ -34,7 +35,13 @@ namespace Amlos.AI.Nodes
         {
             rb = transform.GetComponent<Rigidbody2D>();
             start = transform.position;
-            end = target.PositionValue;
+            try
+            {
+                end = target.PositionValue;
+            } catch (InvalidOperationException e)
+            {
+                Exception(InvalidNodeException.InvalidValue(e.Message, this));
+            }
             _jumpDuration = jumpDuration.NumericValue;
             _jumpHeight = jumpHeight.NumericValue;
         }

--- a/Runtime/Nodes/Actions/Movement/FixedJump.cs
+++ b/Runtime/Nodes/Actions/Movement/FixedJump.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Amlos.AI.Variables;
+﻿using Amlos.AI.Variables;
 using UnityEngine;
 
 namespace Amlos.AI.Nodes
@@ -33,15 +32,13 @@ namespace Amlos.AI.Nodes
 
         public override void Start()
         {
+            if (target.IsNull)
+            {
+                End(false);
+            }
             rb = transform.GetComponent<Rigidbody2D>();
             start = transform.position;
-            try
-            {
-                end = target.PositionValue;
-            } catch (InvalidOperationException e)
-            {
-                Exception(InvalidNodeException.InvalidValue(e.Message, this));
-            }
+            end = target.PositionValue;
             _jumpDuration = jumpDuration.NumericValue;
             _jumpHeight = jumpHeight.NumericValue;
         }

--- a/Runtime/Nodes/Actions/Movement/Movement.cs
+++ b/Runtime/Nodes/Actions/Movement/Movement.cs
@@ -128,6 +128,15 @@ namespace Amlos.AI.Nodes
                         End(false);
                         return;
                     }
+                    try
+                    {
+                        _ = tracingPosition;
+                    }
+                    catch (InvalidOperationException e)
+                    {
+                        Exception(InvalidNodeException.InvalidValue(e.Message, this));
+                        return;
+                    }
                     break;
                 case Behaviour.wander:
                     wanderPosition = GetWanderLocation();

--- a/Runtime/Nodes/Actions/Movement/Movement.cs
+++ b/Runtime/Nodes/Actions/Movement/Movement.cs
@@ -128,15 +128,6 @@ namespace Amlos.AI.Nodes
                         End(false);
                         return;
                     }
-                    try
-                    {
-                        _ = tracingPosition;
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        Exception(InvalidNodeException.InvalidValue(e.Message, this));
-                        return;
-                    }
                     break;
                 case Behaviour.wander:
                     wanderPosition = GetWanderLocation();

--- a/Runtime/Nodes/Arithmetics/Boolean.cs
+++ b/Runtime/Nodes/Arithmetics/Boolean.cs
@@ -13,7 +13,7 @@ namespace Amlos.AI.Nodes
         {
             if (!boolean.HasValue)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(boolean)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(boolean), this));
             }
 
             bool value;

--- a/Runtime/Nodes/Arithmetics/Copy.cs
+++ b/Runtime/Nodes/Arithmetics/Copy.cs
@@ -16,12 +16,12 @@ namespace Amlos.AI.Nodes
         {
             if (!from.HasValue)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(from)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(from), this));
             }
 
             if (!to.HasValue)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(to)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(to), this));
             }
 
             try

--- a/Runtime/Nodes/Arithmetics/DirectionTo.cs
+++ b/Runtime/Nodes/Arithmetics/DirectionTo.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Amlos.AI.Variables;
+﻿using Amlos.AI.Variables;
 using Minerva.Module;
 using UnityEngine;
 
@@ -28,20 +27,17 @@ namespace Amlos.AI.Nodes
                 return HandleException(InvalidNodeException.VariableIsRequired(nameof(target), this));
             }
 
-            if (target.IsNull)
+            if (overrideCenter && !center.HasValue)
+            {
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(center), this));
+            }
+
+            if (target.IsNull || center.IsNull)
             {
                 return State.Failed;
             }
 
-            Vector3 position;
-            try
-            {
-                position = target.PositionValue;
-            }
-            catch (InvalidOperationException e)
-            {
-                return HandleException(InvalidNodeException.InvalidValue(e.Message, this));
-            }
+            Vector3 position = target.PositionValue;
             Vector3 source = overrideCenter ? center.PositionValue : transform.position;
 
             var displacement = position - source;

--- a/Runtime/Nodes/Arithmetics/DirectionTo.cs
+++ b/Runtime/Nodes/Arithmetics/DirectionTo.cs
@@ -1,4 +1,5 @@
-﻿using Amlos.AI.Variables;
+﻿using System;
+using Amlos.AI.Variables;
 using Minerva.Module;
 using UnityEngine;
 
@@ -24,7 +25,7 @@ namespace Amlos.AI.Nodes
         {
             if (!target.HasValue)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(target)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(target), this));
             }
 
             if (target.IsNull)
@@ -32,11 +33,20 @@ namespace Amlos.AI.Nodes
                 return State.Failed;
             }
 
-            Vector3 position = target.PositionValue;
+            Vector3 position;
+            try
+            {
+                position = target.PositionValue;
+            }
+            catch (InvalidOperationException e)
+            {
+                return HandleException(InvalidNodeException.InvalidValue(e.Message, this));
+            }
             Vector3 source = overrideCenter ? center.PositionValue : transform.position;
 
             var displacement = position - source;
             result.SetValue(displacement.normalized);
+
             return State.Success;
         }
     }

--- a/Runtime/Nodes/Arithmetics/Random.cs
+++ b/Runtime/Nodes/Arithmetics/Random.cs
@@ -32,7 +32,7 @@ namespace Amlos.AI.Nodes
         {
             if (!result.HasReference)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(result)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(result), this));
             }
 
             switch (type)
@@ -40,11 +40,11 @@ namespace Amlos.AI.Nodes
                 case Type.range:
                     if (!min.HasValue)
                     {
-                        return HandleException(InvalidNodeException.VariableIsRequired(nameof(min)));
+                        return HandleException(InvalidNodeException.VariableIsRequired(nameof(min), this));
                     }
                     if (!max.HasValue)
                     {
-                        return HandleException(InvalidNodeException.VariableIsRequired(nameof(max)));
+                        return HandleException(InvalidNodeException.VariableIsRequired(nameof(max), this));
                     }
                     if (result.Type == VariableType.Int)
                     {

--- a/Runtime/Nodes/Arithmetics/TypeObject.cs
+++ b/Runtime/Nodes/Arithmetics/TypeObject.cs
@@ -14,7 +14,7 @@ namespace Amlos.AI.Nodes
         {
             if (!typeReference.HasReferType)
             {
-                return HandleException(InvalidNodeException.VariableIsRequired(nameof(typeReference)));
+                return HandleException(InvalidNodeException.VariableIsRequired(nameof(typeReference), this));
             }
             if (result.HasValue)
             {

--- a/Runtime/Nodes/Arithmetics/TypeOf.cs
+++ b/Runtime/Nodes/Arithmetics/TypeOf.cs
@@ -16,7 +16,7 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                throw InvalidNodeException.VariableIsRequired(nameof(variable));
+                throw InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             if (result.HasReference) result.SetValue(variable.Value?.GetType());
             return StateOf(variable.Value != null);

--- a/Runtime/Nodes/Determines/IsComponent.cs
+++ b/Runtime/Nodes/Determines/IsComponent.cs
@@ -14,7 +14,7 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(variable));
+                return InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/IsComponentOrGameObject.cs
+++ b/Runtime/Nodes/Determines/IsComponentOrGameObject.cs
@@ -14,7 +14,7 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(variable));
+                return InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/IsGameObject.cs
+++ b/Runtime/Nodes/Determines/IsGameObject.cs
@@ -13,7 +13,7 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(variable));
+                return InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/IsInScreen.cs
+++ b/Runtime/Nodes/Determines/IsInScreen.cs
@@ -1,4 +1,5 @@
-﻿using Amlos.AI.Variables;
+﻿using System;
+using Amlos.AI.Variables;
 using UnityEngine;
 
 namespace Amlos.AI.Nodes
@@ -9,7 +10,21 @@ namespace Amlos.AI.Nodes
         [Constraint(VariableType.UnityObject, VariableType.Vector2, VariableType.Vector3)]
         [Readable]
         public VariableReference position;
-
+        public override Exception IsValidNode()
+        {
+            if (!position.HasValue)
+            {
+                return InvalidNodeException.VariableIsRequired(nameof(position), this);
+            }
+            try
+            {
+                _ = position.PositionValue;
+            } catch (InvalidOperationException e)
+            {
+                return InvalidNodeException.InvalidValue(e.Message, this);
+            }
+            return null;
+        }
         public override bool GetValue()
         {
             Vector3 position = this.position.PositionValue;

--- a/Runtime/Nodes/Determines/IsInScreen.cs
+++ b/Runtime/Nodes/Determines/IsInScreen.cs
@@ -16,17 +16,14 @@ namespace Amlos.AI.Nodes
             {
                 return InvalidNodeException.VariableIsRequired(nameof(position), this);
             }
-            try
-            {
-                _ = position.PositionValue;
-            } catch (InvalidOperationException e)
-            {
-                return InvalidNodeException.InvalidValue(e.Message, this);
-            }
             return null;
         }
         public override bool GetValue()
         {
+            if (this.position.IsNull)
+            {
+                return false;
+            }
             Vector3 position = this.position.PositionValue;
             var camPoint = Camera.main.WorldToScreenPoint(position);
             // out of screen

--- a/Runtime/Nodes/Determines/IsInVision.cs
+++ b/Runtime/Nodes/Determines/IsInVision.cs
@@ -26,7 +26,14 @@ namespace Amlos.AI.Nodes
         {
             if (!target.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(target));
+                return InvalidNodeException.VariableIsRequired(nameof(target), this);
+            }
+            try
+            {
+                _ = target.PositionValue;
+            } catch (InvalidOperationException e)
+            {
+                return InvalidNodeException.InvalidValue(e.Message, this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/IsInVision.cs
+++ b/Runtime/Nodes/Determines/IsInVision.cs
@@ -28,13 +28,6 @@ namespace Amlos.AI.Nodes
             {
                 return InvalidNodeException.VariableIsRequired(nameof(target), this);
             }
-            try
-            {
-                _ = target.PositionValue;
-            } catch (InvalidOperationException e)
-            {
-                return InvalidNodeException.InvalidValue(e.Message, this);
-            }
             return null;
         }
         

--- a/Runtime/Nodes/Determines/IsNull.cs
+++ b/Runtime/Nodes/Determines/IsNull.cs
@@ -15,7 +15,7 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(variable));
+                return InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/IsTypeOf.cs
+++ b/Runtime/Nodes/Determines/IsTypeOf.cs
@@ -17,11 +17,11 @@ namespace Amlos.AI.Nodes
         {
             if (!variable.HasValue)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(variable));
+                return InvalidNodeException.VariableIsRequired(nameof(variable), this);
             }
             if (!type.HasReferType)
             {
-                return InvalidNodeException.VariableIsRequired(nameof(type));
+                return InvalidNodeException.VariableIsRequired(nameof(type), this);
             }
             return null;
         }

--- a/Runtime/Nodes/Determines/RaycastDistance.cs
+++ b/Runtime/Nodes/Determines/RaycastDistance.cs
@@ -1,4 +1,5 @@
-﻿using Amlos.AI.Variables;
+﻿using System;
+using Amlos.AI.Variables;
 using UnityEngine;
 
 namespace Amlos.AI.Nodes
@@ -24,7 +25,21 @@ namespace Amlos.AI.Nodes
         public VariableField<LayerMask> layerMask;
 
 
-
+        public override Exception IsValidNode()
+        {
+            if (!center.HasValue)
+            {
+                return InvalidNodeException.VariableIsRequired(nameof(center), this);
+            }
+            try
+            {
+                _ = center.PositionValue;
+            } catch (InvalidOperationException e)
+            {
+                return InvalidNodeException.InvalidValue(e.Message, this);
+            }
+            return null;
+        }
 
         public override float GetValue()
         {

--- a/Runtime/Nodes/Flows/WaitUntil.cs
+++ b/Runtime/Nodes/Flows/WaitUntil.cs
@@ -10,7 +10,7 @@ namespace Amlos.AI.Nodes
         {
             if (condition is not null && condition.HasReference)
                 return SetNextExecute(condition);
-            return HandleException(InvalidNodeException.ReferenceIsRequired(nameof(condition)));
+            return HandleException(InvalidNodeException.ReferenceIsRequired(nameof(condition), this));
         }
 
         public override State ReceiveReturnFromChild(bool @return)

--- a/Runtime/Nodes/Flows/WaitWhile.cs
+++ b/Runtime/Nodes/Flows/WaitWhile.cs
@@ -10,7 +10,7 @@ namespace Amlos.AI.Nodes
         {
             if (condition is not null && condition.HasReference)
                 return SetNextExecute(condition);
-            return HandleException(InvalidNodeException.ReferenceIsRequired(nameof(condition)));
+            return HandleException(InvalidNodeException.ReferenceIsRequired(nameof(condition), this));
         }
 
         public override State ReceiveReturnFromChild(bool @return)

--- a/Runtime/Tree/BehaviourTree.NodeCallStack.cs
+++ b/Runtime/Tree/BehaviourTree.NodeCallStack.cs
@@ -1,4 +1,4 @@
-﻿using Amlos.AI.Nodes;
+using Amlos.AI.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -104,6 +104,7 @@ namespace Amlos.AI
                 {
                     if (t.IsFaulted)
                     {
+                        Debug.LogError($"Exception occurred at node [{Current?.name}]");
                         Debug.LogException(t.Exception);
                         End();
                     }
@@ -234,7 +235,7 @@ namespace Amlos.AI
                                 await Awaitable.NextFrameAsync();
 #else
                                 await Task.Yield();
-#endif 
+#endif
                                 r = Amlos.AI.Nodes.State.Failed;
                             }
                             catch (Exception)

--- a/Runtime/Tree/InvalidNodeException.cs
+++ b/Runtime/Tree/InvalidNodeException.cs
@@ -1,38 +1,77 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using Amlos.AI.Nodes;
 
 namespace Amlos.AI
 {
     [Serializable]
     public class InvalidNodeException : Exception
     {
+        public Type NodeType { get; }
+
         public InvalidNodeException() { }
-        public InvalidNodeException(string message) : base(message) { }
-        public InvalidNodeException(string message, Exception inner) : base(message, inner) { }
-        protected InvalidNodeException(
-          SerializationInfo info,
-          StreamingContext context) : base(info, context) { }
 
-
-
-        public static InvalidNodeException VariableIsRequired(string varName)
+        public InvalidNodeException(string message, Type nodeType = null)
+            : base(AppendNodeName(message, nodeType))
         {
-            return new InvalidNodeException($"Variable \"{varName}\" is required");
+            NodeType = nodeType;
         }
 
-        public static InvalidNodeException InvalidValue(string varName, object value)
+        public InvalidNodeException(string message, Exception inner, Type nodeType = null)
+            : base(AppendNodeName(message, nodeType), inner)
         {
-            return new InvalidNodeException($"Variable \"{varName}\" has invalid value: {value}");
+            NodeType = nodeType;
         }
 
-        public static InvalidNodeException InvalidValue(VariableType type, object value)
+        protected InvalidNodeException(SerializationInfo info, StreamingContext context)
+            : base(info, context) { }
+
+        private static string AppendNodeName(string msg, Type nodeType)
         {
-            return new InvalidNodeException($"Variable Type \"{type}\" has invalid value: {value}");
+            if (nodeType == null) return msg;
+            return $"[{nodeType.Name}] {msg}";
         }
 
-        public static InvalidNodeException ReferenceIsRequired(string varName)
+        public static InvalidNodeException VariableIsRequired(string varName, TreeNode node)
         {
-            return new InvalidNodeException($"Children \"{varName}\" is required");
+            return new InvalidNodeException(
+                $"Variable \"{varName}\" is required",
+                node.GetType()
+            );
+        }
+
+        // VariableBase throws InvalidOperationException instead
+        // public static InvalidNodeException InvalidValue(string varName, object value, TreeNode node)
+        // {
+        //     return new InvalidNodeException(
+        //         $"Variable \"{varName}\" has invalid value: {value}",
+        //         node.GetType()
+        //     );
+        // }
+
+        // public static InvalidNodeException InvalidValue(VariableType type, object value, TreeNode node)
+        // {
+        //     return new InvalidNodeException(
+        //         $"Variable Type \"{type}\" has invalid value: {value}",
+        //         node.GetType()
+        //     );
+        // }
+
+        public static InvalidNodeException InvalidValue(string message, TreeNode node)
+        {
+            return new InvalidNodeException(
+                message,
+                node.GetType()
+            );
+        }
+
+        public static InvalidNodeException ReferenceIsRequired(string varName, TreeNode node)
+        {
+            return new InvalidNodeException(
+                $"Children \"{varName}\" is required",
+                node.GetType()
+            );
         }
     }
+
 }


### PR DESCRIPTION
Added TreeNode type to be shown in AI exception logs. Such as [lslnVision] Variable "target" is required.

Must merge together with feature/treenode-type-exception-log in library-of-meialia